### PR TITLE
improve callback system

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # NetworkDynamics Release Notes
 
+## v0.10.10 Changelog
+- [#317](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/317) Enhanced callback system with negative affect support and runtime callback injection:
+  - Add `affect_neg!` parameter to `ContinuousComponentCallback` and `VectorContinuousComponentCallback` for handling downcrossing events
+  - Add ability to inject additional callbacks at runtime via `get_callbacks(nw, additional_callbacks)` without storing them in component metadata
+  - Add `NetworkDynamics.pretty_f()` debugging utility for pretty-printing MTK-generated functions
+  - Improve MTK integration warnings for nested event systems
+  - Better initialization error messages with specific variable information when NaN values are detected
+
 ## v0.10.9 Changelog
 - [#314](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/314) Consolidate deprecated functionality: all deprecated functionality moved to dedicated `src/deprecated.jl` file for easier maintenance
 

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -219,6 +219,7 @@ has_callback
 get_callbacks(::NetworkDynamics.ComponentModel)
 set_callback!
 add_callback!
+delete_callbacks!
 ```
 
 ## Sparsity Detection

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -253,6 +253,7 @@ ff_to_constraint
 Base.copy(::NetworkDynamics.ComponentModel)
 extract_nw
 implicit_output
+NetworkDynamics.pretty_f
 ```
 
 ## NetworkDynamicsInspector API

--- a/ext/MTKExt_utils.jl
+++ b/ext/MTKExt_utils.jl
@@ -149,15 +149,27 @@ function generate_massmatrix(eqs::AbstractVector{Equation})
 end
 
 function warn_missing_features(sys)
-    cev = ModelingToolkit.get_continuous_events(sys)
-    dev = ModelingToolkit.get_discrete_events(sys)
+    cev = _collect_continuous_events(sys)
+    dev = _collect_discrete_events(sys)
     if !isempty(cev) || !isempty(dev)
-        @warn "Model has attached events, which is not supported."
+        @warn "MTK-Model $(sys.name) contains events. They will be ignored by NetworkDynamics.jl. Use ComponentCallbacks on a component level for that!"
     end
 
     if !isempty(ModelingToolkit.initialization_equations(sys))
         @warn "Model has explicit init equation. Those are currently ignored by NetworkDynamics.jl."
     end
+end
+function _collect_continuous_events(sys)
+    vcat(
+        ModelingToolkit.get_continuous_events(sys),
+        [_collect_continuous_events(sys) for sys in ModelingToolkit.get_systems(sys)]...
+    )
+end
+function _collect_discrete_events(sys)
+    vcat(
+        ModelingToolkit.get_discrete_events(sys),
+        [_collect_discrete_events(sys) for sys in ModelingToolkit.get_systems(sys)]...
+    )
 end
 
 function check_metadata(exprs)

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -100,7 +100,7 @@ export has_init, get_init, set_init!, delete_init!, strip_inits!
 export has_bounds, get_bounds, set_bounds!, delete_bounds!, strip_bounds!
 export has_graphelement, get_graphelement, set_graphelement!
 export get_initial_state, dump_initial_state, dump_state
-export has_callback, get_callbacks, set_callback!, add_callback!
+export has_callback, get_callbacks, set_callback!, add_callback!, delete_callbacks!
 export has_initconstraint, get_initconstraints, set_initconstraint!, add_initconstraint!, delete_initconstraints!
 export has_initformula, get_initformulas, set_initformula!, add_initformula!, delete_initformulas!
 export has_position, get_position, set_position!

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -23,6 +23,7 @@ using Random: Random
 using Static: Static, StaticInt
 using SciMLBase: VectorContinuousCallback, CallbackSet, DiscreteCallback
 using DiffEqCallbacks: DiffEqCallbacks
+using MacroTools: postwalk, @capture
 
 @static if VERSION ≥ v"1.11.0-0"
     using Base: AnnotatedIOBuffer, AnnotatedString
@@ -79,7 +80,6 @@ export DiscreteComponentCallback, PresetTimeComponentCallback
 export SymbolicView
 include("callbacks.jl")
 
-using MacroTools: postwalk
 export @initconstraint, InitConstraint
 export @initformula, InitFormula
 include("init_constraints.jl")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -123,21 +123,18 @@ callbacks are collected for the whole network using `get_callbacks`.
 [`DiffEq.jl docs`](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/)
 for available options.
 """
-struct ContinuousComponentCallback{C,CDIM,CPDIM,A,ADIM,APDIM,An,AnDIM,AnPDIM} <: ComponentCallback
-    condition::ComponentCondition{C,CDIM,CPDIM}
-    affect::ComponentAffect{A,ADIM,APDIM}
-    affect_neg::Union{Nothing,ComponentAffect{An,AnDIM,AnPDIM}}
+struct ContinuousComponentCallback{
+    C  <: ComponentCondition,
+    A  <: ComponentAffect,
+    An <: Union{ComponentAffect,Nothing}
+} <: ComponentCallback
+    condition::C
+    affect::A
+    affect_neg::An
     kwargs::NamedTuple
 end
 function ContinuousComponentCallback(condition, affect; affect_neg! = affect, kwargs...)
-    if affect_neg! == nothing
-        ContinuousComponentCallback{_get_type_parameters(condition,affect)...,Nothing,Nothing,Nothing}(condition, affect, nothing, NamedTuple(kwargs))
-    else
-        ContinuousComponentCallback(condition, affect, affect_neg!, NamedTuple(kwargs))
-    end
-end
-function _get_type_parameters(condition::ComponentCondition{C,CDIM,CPDIM}, affect::ComponentAffect{A,ADIM,APDIM}) where {C,CDIM,CPDIM,A,ADIM,APDIM}
-    C, CDIM, CPDIM, A, ADIM, APDIM
+    ContinuousComponentCallback(condition, affect, affect_neg!, NamedTuple(kwargs))
 end
 
 """
@@ -158,19 +155,19 @@ callbacks are collected for the whole network using [`get_callbacks(::Network)`]
 [`DiffEq.jl docs`](https://docs.sciml.ai/DiffEqDocs/stable/features/callback_functions/)
 for available options.
 """
-struct VectorContinuousComponentCallback{C,CDIM,CPDIM,A,ADIM,APDIM,An,AnDIM,AnPDIM} <: ComponentCallback
-    condition::ComponentCondition{C,CDIM,CPDIM}
-    affect::ComponentAffect{A,ADIM,APDIM}
-    affect_neg::Union{Nothing,ComponentAffect{An,AnDIM,AnPDIM}}
+struct VectorContinuousComponentCallback{
+    C  <: ComponentCondition,
+    A  <: ComponentAffect,
+    An <: Union{ComponentAffect,Nothing}
+} <: ComponentCallback
+    condition::C
+    affect::A
+    affect_neg::An
     len::Int
     kwargs::NamedTuple
 end
 function VectorContinuousComponentCallback(condition, affect, len; affect_neg! = affect, kwargs...)
-    if affect_neg! == nothing
-        VectorContinuousComponentCallback{_get_type_parameters(condition,affect)...,Nothing,Nothing,Nothing}(condition, affect, nothing, len, NamedTuple(kwargs))
-    else
-        VectorContinuousComponentCallback(condition, affect, affect_neg!, len, NamedTuple(kwargs))
-    end
+    VectorContinuousComponentCallback(condition, affect, affect_neg!, len, NamedTuple(kwargs))
 end
 
 """

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -65,7 +65,11 @@ function find_fixpoint(nw::Network, x0::AbstractVector, p::AbstractVector;
         # something bad happened
         io = IOBuffer()
         if isnothing(fn_error)
-            print(io, "Evaluation of network rhs at t=$t resulted in NaNs! Probable causes:")
+            nans = findall(isnan, du)
+            syms = SII.variable_symbols(nw)[nans]
+            println(io, "Evaluation of network rhs at t=$t resulted in NaNs.)")
+            println(io, "  NaN-Results:  ", join(syms, ", "))
+            print(io,"Probable causes:")
         else
             print(io, "Evaluation of network rhs at t=$t led to an error! Probable causes:")
         end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -595,6 +595,20 @@ end
 add_callback!(nw::Network, idx::VCIndex, cb; kw...) = add_callback!(getcomp(nw, idx), cb; kw...)
 add_callback!(nw::Network, idx::ECIndex, cb; kw...) = add_callback!(getcomp(nw, idx), cb; kw...)
 
+"""
+    delete_callbacks!(c::ComponentModel)
+    delete_callbacks!(nw::Network, idx::Union{VIndex,EIndex})
+
+Removes all callback functions from the component model,
+or from a component referenced by `idx` in a network.
+Returns `true` if callbacks existed and were removed, `false` otherwise.
+
+See also: [`set_callback!`](@ref), [`add_callback!`](@ref).
+"""
+delete_callbacks!(c::ComponentModel) = delete_metadata!(c, :callback)
+delete_callbacks!(nw::Network, idx::VCIndex) = delete_callbacks!(getcomp(nw, idx))
+delete_callbacks!(nw::Network, idx::ECIndex) = delete_callbacks!(getcomp(nw, idx))
+
 ####
 #### Init constraints
 ####

--- a/src/show.jl
+++ b/src/show.jl
@@ -6,6 +6,7 @@ function Base.show(io::IO, @nospecialize(nw::Network))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", @nospecialize(nw::Network))
+    aliased_changed(nw, warn=true)
     compact = get(io, :compact, false)::Bool
     if compact
         print(io, "Network ($(nv(nw.im.g)) vertices, $(ne(nw.im.g)) edges)")

--- a/src/show.jl
+++ b/src/show.jl
@@ -663,11 +663,18 @@ function _print_condsyms(io, @nospecialize(cb::ComponentCallback))
 end
 function _print_affectsyms(io, @nospecialize(cb::ComponentCallback))
     print(io, "(")
-    _print_syms(io, cb.affect.sym, true)
-    _print_syms(io, cb.affect.psym, isempty(cb.affect.sym))
+    if cb isa Union{PresetTimeComponentCallback, DiscreteComponentCallback} || getaffect_neg(cb) === nothing || getaffect_neg(cb) == getaffect(cb)
+        syms = getaffect(cb).sym
+        psyms = getaffect(cb).psym
+    else
+        syms = vcat(collect(getaffect(cb).sym), collect(getaffect_neg(cb).sym)) |> unique!
+        psyms = vcat(collect(getaffect(cb).psym), collect(getaffect_neg(cb).psym)) |> unique!
+    end
+    _print_syms(io, syms, true)
+    _print_syms(io, psyms, isempty(cb.affect.sym))
     print(io, ")")
 end
-function _print_syms(io, syms::Tuple, isfirst)
+function _print_syms(io, syms, isfirst)
     for s in syms
         if !isfirst
             print(io, ", ")

--- a/test/callbacks_test.jl
+++ b/test/callbacks_test.jl
@@ -257,8 +257,7 @@ end
     @test_throws ArgumentError set_callback!(nw.im.edgem[1], cb)
 end
 
-# @testset "check callbacks with different affneg" begin
-begin
+@testset "check callbacks with different affneg" begin
     f = (du, u, in, p, t) -> begin
         du[1] = -sin(t)
         du[2] = cos(t)

--- a/test/callbacks_test.jl
+++ b/test/callbacks_test.jl
@@ -131,6 +131,11 @@ end
     affect = ComponentAffect(empty_function, [:ω],[])
     cb3 = ContinuousComponentCallback(cond, affect; affect_neg! = nothing)
     show(stdout, MIME"text/plain"(), cb3)
+
+    # test delete
+    @test delete_callbacks!(v)
+    @test !has_callback(v)
+    @test !delete_callbacks!(v)
 end
 
 @testset "vector callbacks" begin

--- a/test/symbolicindexing_test.jl
+++ b/test/symbolicindexing_test.jl
@@ -226,6 +226,17 @@ end
         @test s.v[1, StateIdx(:)] == [4, 5]
         s.v[1, StateIdx(:)] = [7,8]
         @test s.v[1, StateIdx(:)] == [7, 8]
+
+        s.v(varfilter=r"foo")
+        FilteringProxy(s)(varfilter="foo")
+        NetworkDynamics._explain_compfilter(VIndex(1:2))
+        NetworkDynamics._explain_compfilter(VIndex(:concrete_name))
+        NetworkDynamics._explain_compfilter([VIndex(:concrete_name), EIndex(:)])
+        NetworkDynamics._explain_compfilter([VIndex(:concrete_name), EIndex(r"foo")])
+        NetworkDynamics._explain_compfilter(VIndex(["foo", r"bar"]))
+        s.v["foo"]
+        s.e[:](r"unmatched_regex")
+        s.v[["foo", 1:2, r"bar"]](["foo", :bar])
     end
 
     @testset "Test colon indexing" begin


### PR DESCRIPTION
  - Add `affect_neg!` parameter to `ContinuousComponentCallback` and `VectorContinuousComponentCallback` for handling downcrossing events (fixes #296 )
  - Add ability to inject additional callbacks at runtime via `get_callbacks(nw, additional_callbacks)` without storing them in component metadata (fixes #315)
  - Add `NetworkDynamics.pretty_f()` debugging utility for pretty-printing MTK-generated functions
  - Improve MTK integration warnings for nested event systems
  - Better initialization error messages with specific variable information when NaN values are detected

[no benchmark]
