### PR TITLE
Fix apparent bug in NetworkDynamicsInspector:serve_app

### DIFF
--- a/NetworkDynamicsInspector/src/serving.jl
+++ b/NetworkDynamicsInspector/src/serving.jl
@@ -26,7 +26,7 @@ end
 """
     get_display(::NDIDisplay; restart, kwargs...)
 """
-function serve_app(display, app)
+function serve_app(disp, app)
     if disp isa ElectronDisp
         @error "Electron.jl not available. Please install Electron.jl and `using Electron` before calling this function."
     else


### PR DESCRIPTION
Locally tested: after renaming, inspector can be now started in an Electron window.