### PR TITLE
add assume_io_coupling kw arg to MTK constructors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,4 +14,4 @@ steps:
       queue: "juliagpu"
       cuda: "*"
     if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 60
+    timeout_in_minutes: 120

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
   - New optional parameter forces MTK to consider direct dependency chains from outputs to inputs
   - Helps resolve cases where MTK simplification results in derivatives of input variables
 - Improved error handling for RHS differentials with new `RHSDifferentialsError` exception type that provides helpful guidance
+- fix performance bottleneck in MTK model "compilation"
 
 ## v0.10.13 Changelog
 Multiple new features from [#331](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/331):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # NetworkDynamics Release Notes
 
+## v0.10.14 Changelog
+- Add `assume_io_coupling` parameter to MTK `VertexModel` and `EdgeModel` constructors ([#332](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/332))
+  - New optional parameter forces MTK to consider direct dependency chains from outputs to inputs
+  - Helps resolve cases where MTK simplification results in derivatives of input variables
+- Improved error handling for RHS differentials with new `RHSDifferentialsError` exception type that provides helpful guidance
+
 ## v0.10.13 Changelog
 Multiple new features from [#331](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/331):
 - Parallel component initialization: Add experimental `parallel=false` keyword to `initialize_componentwise` for multithreaded component initialization with visual progress indicators

--- a/ext/NetworkDynamicsMTKExt.jl
+++ b/ext/NetworkDynamicsMTKExt.jl
@@ -330,7 +330,7 @@ function generate_io_function(_sys, inputss::Tuple, outputss::Tuple;
         if !isempty(implicit_outputs)
             throw(
                 ArgumentError("The outputs $(getname.(implicit_outputs)) do not appear in the equations of the system! \
-                    Try to to make them explicit using `implicit_output`\n" *
+                    Try to to make them explicit using the keyword `assume_io_coupling` or the more manual `implicit_output`\n" *
                     NetworkDynamics.implicit_output_docstring)
             )
         end

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -128,9 +128,10 @@ function find_fixpoint(nw::Network, x0::AbstractVector, p::AbstractVector;
 
     prob = SteadyStateProblem(nw_fixed_t, x0, p)
     sol = SciMLBase.solve(prob, alg; kwargs...)
+    resid = maximum(abs.(sol.resid))
     if !SciMLBase.successful_retcode(sol.retcode)
         throw(NetworkInitError("""
-        Could not find fixpoint, solver returned $(sol.retcode) (alg=$(alg))! For debugging, \
+        Could not find fixpoint, solver returned $(sol.retcode) with residual $(resid) (alg=$(alg))! For debugging, \
         it is advised to manually construct the steady state problem and try \
         different solvers/arguments:
 

--- a/src/linear_stability.jl
+++ b/src/linear_stability.jl
@@ -31,6 +31,7 @@ See [`jacobian_eigenvals`](@ref) for more details.
 - `nw::Network`: The network dynamics object
 - `s0::NWState`: The state to check for linear stability (must be a fixpoint)
 - `marginally_stable::Bool=false`: If `true`, eigenvalues with zero real part are considered stable.
+- `atol::Float64=1e-14`: Absolute tolerance for determining marginal stability. When `marginally_stable=true`, eigenvalues with `|real(λ)| < atol` are treated as having zero real part.
 - `kwargs...`: Additional keyword arguments passed to `jacobian_eigenvals`
 
 # Returns
@@ -39,10 +40,14 @@ See [`jacobian_eigenvals`](@ref) for more details.
 # References
 [1] "Power System Modelling and Scripting", F. Milano, Chapter 7.2.
 """
-function is_linear_stable(nw::Network, s0; marginally_stable=false, kwargs...)
+function is_linear_stable(nw::Network, s0; marginally_stable=false, atol=1e-14, kwargs...)
     isfixpoint(nw, s0) || error("The state s0 is not a fixpoint of the network nw.")
     λ = jacobian_eigenvals(nw, s0; kwargs...)
-    comparator = marginally_stable ? (λ -> real(λ) ≤ 0.0) : (λ -> real(λ) < 0.0)
+    comparator = if marginally_stable
+        λ -> real(λ) - atol < 0.0 || isapprox(real(λ), 0.0; atol)
+    else
+        λ -> real(λ) < 0.0
+    end
     if all(comparator, λ)
         return true
     else

--- a/src/linear_stability.jl
+++ b/src/linear_stability.jl
@@ -17,7 +17,7 @@ function isfixpoint(nw::Network, s0::NWState; tol=1e-10)
 end
 
 """
-    is_linear_stable(nw::Network, s0::NWState; kwargs...)
+    is_linear_stable(nw::Network, s0::NWState; marginally_stable=false, kwargs...)
 
 Check if the fixpoint `s0` of the network `nw` is linearly stable by computing
 the eigenvalues of the Jacobian matrix (or reduced Jacobian for constrained systems).
@@ -30,6 +30,7 @@ See [`jacobian_eigenvals`](@ref) for more details.
 # Arguments
 - `nw::Network`: The network dynamics object
 - `s0::NWState`: The state to check for linear stability (must be a fixpoint)
+- `marginally_stable::Bool=false`: If `true`, eigenvalues with zero real part are considered stable.
 - `kwargs...`: Additional keyword arguments passed to `jacobian_eigenvals`
 
 # Returns
@@ -38,10 +39,11 @@ See [`jacobian_eigenvals`](@ref) for more details.
 # References
 [1] "Power System Modelling and Scripting", F. Milano, Chapter 7.2.
 """
-function is_linear_stable(nw::Network, s0; kwargs...)
+function is_linear_stable(nw::Network, s0; marginally_stable=false, kwargs...)
     isfixpoint(nw, s0) || error("The state s0 is not a fixpoint of the network nw.")
     λ = jacobian_eigenvals(nw, s0; kwargs...)
-    if all(λ -> real(λ) < 0.0, λ)
+    comparator = marginally_stable ? (λ -> real(λ) ≤ 0.0) : (λ -> real(λ) < 0.0)
+    if all(comparator, λ)
         return true
     else
         return false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -424,3 +424,15 @@ end
     g.g(_out, _args...)
     nothing
 end
+
+
+struct RHSDifferentialsError <: Exception
+    diffs::Vector{String}
+end
+function Base.showerror(io::IO, e::RHSDifferentialsError)
+    println(io, "RHSDifferentialsError: The RHS of the reduced system contains derivatives for the following symbols:")
+    for d in e.diffs
+        println(io, " - ", d)
+    end
+    print(io, "Consider passing `assume_io_coupling=true` to the component constructor!")
+end

--- a/test/linear_stability_test.jl
+++ b/test/linear_stability_test.jl
@@ -49,14 +49,14 @@ using Test
         nw = Network(g, vertex_model, edge_model)
 
         # Set up parameters
-        p = NWParameter(nw)
-        p.v[:, :Pm] .= [1, -0.5, -0.5, 0]  # Power injections
-        p.v[:, :M] .= 1.0  # Inertia
-        p.v[:, :D] .= 0.1  # Damping
-        p.e[:, :K] .= 2.0  # Coupling strength
+        s = NWState(nw)
+        s.p.v[:, :Pm] .= [1, -0.5, -0.5, 0]  # Power injections
+        s.p.v[:, :M] .= 1.0  # Inertia
+        s.p.v[:, :D] .= 0.2  # Damping
+        s.p.e[:, :K] .= 2.0  # Coupling strength
 
         # Find fixpoint
-        s0 = find_fixpoint(nw, p)
+        s0 = find_fixpoint(nw, s)
 
         # Test fixpoint check
         @test isfixpoint(nw, s0)
@@ -66,7 +66,7 @@ using Test
         @test length(λ) == 8  # 4 nodes × 2 states each
 
         # Test stability (should be stable for this configuration)
-        @test is_linear_stable(nw, s0)
+        @test is_linear_stable(nw, s0; marginally_stable=true)
 
         # Test that eigenvalues can be complex
         @test any(isa.(λ, Complex))

--- a/test/linear_stability_test.jl
+++ b/test/linear_stability_test.jl
@@ -65,6 +65,8 @@ using Test
         λ = jacobian_eigenvals(nw, s0)
         @test length(λ) == 8  # 4 nodes × 2 states each
 
+        @info "Kuramoto eigenvalues: " λ
+
         # Test stability (should be stable for this configuration)
         @test is_linear_stable(nw, s0; marginally_stable=true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,10 +13,11 @@ using ExplicitImports
 
 (isinteractive() ? includet : include)(joinpath(pkgdir(NetworkDynamics, "test", "testutils.jl")))
 
-haskey(ENV, "BUILDKITE") && @test CUDA.functional() # fail early in buildkite if cuda is not available
+BUILDKITE = haskey(ENV, "BUILDKITE")
+BUILDKITE && @test CUDA.functional() # fail early in buildkite if cuda is not available
 
 @testset "NetworkDynamics Tests" begin
-    @testset "Package Quality Tests" begin
+    BUILDKITE || @testset "Package Quality Tests" begin
         # print_explicit_imports(NetworkDynamics)
         @test check_no_implicit_imports(NetworkDynamics) === nothing
         @test check_no_stale_explicit_imports(NetworkDynamics, ignore=(:Symbolics,)) === nothing
@@ -27,41 +28,44 @@ haskey(ENV, "BUILDKITE") && @test CUDA.functional() # fail early in buildkite if
         @test_broken isempty(Docs.undocumented_names(NetworkDynamics))
     end
 
-    @safetestset "utils test" begin include("utils_test.jl") end
+    # skip non-GPU tests on buildkite
+    if !BUILDKITE
+        @safetestset "utils test" begin include("utils_test.jl") end
 
-    NetworkDynamics.CHECK_COMPONENT[] = false
-    @safetestset "construction test" begin include("construction_test.jl") end
-    @safetestset "Aggregation Tests" begin include("aggregators_test.jl") end
-    @safetestset "massmatrix test" begin include("massmatrix_test.jl") end
-    NetworkDynamics.CHECK_COMPONENT[] = true
+        NetworkDynamics.CHECK_COMPONENT[] = false
+        @safetestset "construction test" begin include("construction_test.jl") end
+        @safetestset "Aggregation Tests" begin include("aggregators_test.jl") end
+        @safetestset "massmatrix test" begin include("massmatrix_test.jl") end
+        NetworkDynamics.CHECK_COMPONENT[] = true
+
+        @safetestset "initialization test" begin include("initialization_test.jl") end
+        @safetestset "Callbacks test" begin include("callbacks_test.jl") end
+        @safetestset "Metadata test" begin include("metadata_test.jl") end
+        @safetestset "Linear Stability test" begin include("linear_stability_test.jl") end
+        @safetestset "Show-methods test" begin include("show_test.jl") end
+        @safetestset "Spinners test" begin include("spinners_test.jl") end
+        @safetestset "sparsity test" begin include("sparsity_test.jl") end
+
+        @safetestset "MTK extension test" begin include("MTK_test.jl") end
+
+        # check on the precompile files
+        @safetestset "Precompile workload" begin include("../src/precompile_workload.jl") end
+        @safetestset "MTK precompile workload" begin include("../ext/MTKExt_precomp_workload.jl") end
+
+        @safetestset "AD test" begin include("AD_test.jl") end
+        @safetestset "doctor test" begin include("doctor_test.jl") end
+    end
 
     @safetestset "Symbolic Indexing Tests" begin include("symbolicindexing_test.jl") end
     @safetestset "external input test" begin include("external_inputs_test.jl") end
 
-    @safetestset "doctor test" begin include("doctor_test.jl") end
 
     @safetestset "Diffusion test" begin include("diffusion_test.jl") end
     @safetestset "inhomogeneous test" begin include("inhomogeneous_test.jl") end
-    @safetestset "initialization test" begin include("initialization_test.jl") end
-    @safetestset "Callbacks test" begin include("callbacks_test.jl") end
-    @safetestset "Metadata test" begin include("metadata_test.jl") end
-    @safetestset "Linear Stability test" begin include("linear_stability_test.jl") end
-    @safetestset "Show-methods test" begin include("show_test.jl") end
-    @safetestset "Spinners test" begin include("spinners_test.jl") end
-
-    @safetestset "sparsity test" begin include("sparsity_test.jl") end
 
     if CUDA.functional()
         @safetestset "GPU test" begin include("GPU_test.jl") end
     end
-
-    @safetestset "MTK extension test" begin include("MTK_test.jl") end
-
-    # check on the precompile files
-    @safetestset "Precompile workload" begin include("../src/precompile_workload.jl") end
-    @safetestset "MTK precompile workload" begin include("../ext/MTKExt_precomp_workload.jl") end
-
-    @safetestset "AD test" begin include("AD_test.jl") end
 end
 
 @testset "Test Doc Examples" begin


### PR DESCRIPTION
this introduces a "fake" dependency on output states on all equations including input states, thus may help MTK with simplification

[no benchmark]