### PR TITLE
fix init macros

### DIFF
--- a/src/init_constraints.jl
+++ b/src/init_constraints.jl
@@ -140,18 +140,20 @@ macro initconstraint(ex)
         constraint isa Union{Expr, QuoteNode} || continue # skip line number nodes
         dim += 1
         wrapped = _wrap_symbols!(constraint, sym, u)
-        push!(body, :($(esc(out))[$dim] = $wrapped))
+        push!(body, :($out[$dim] = $wrapped))
     end
     unique!(sym)
 
     s = join(string.(body), "\n")
-    s = replace(s, "(\$(Expr(:escape, :$out)))" => "    out")
-    s = replace(s, "(\$(Expr(:escape, :$u)))" => "u")
+    s = replace(s, string(out) => "    out")
+    s = replace(s, string(u) => "u")
     s = "InitConstraint($sym, $dim) do out, u\n" * s * "\nend"
+
+    body_esc = _escape_all.(body)
 
     quote
         InitConstraint($sym, $dim, $s) do $(esc(out)), $(esc(u))
-            $(body...)
+            $(body_esc...)
             nothing
         end
     end
@@ -160,7 +162,16 @@ function _wrap_symbols!(ex, sym, u)
     postwalk(ex) do x
         if x isa QuoteNode && x.value isa Symbol
             push!(sym, x.value)
-            :($(esc(u))[$x])
+            :($u[$x])
+        else
+            x
+        end
+    end
+end
+function _escape_all(ex::Expr)
+    postwalk(ex) do x
+        if x isa Symbol
+            esc(x)
         else
             x
         end
@@ -471,7 +482,7 @@ function _formula_macro(type, ex)
                 # :output = ... assigmend
                 target_sym = lhs.value
                 push!(output_syms, target_sym)
-                push!(body, :($(esc(out_var))[$(QuoteNode(target_sym))] = $wrapped_rhs))
+                push!(body, :($out_var[$(QuoteNode(target_sym))] = $wrapped_rhs))
             else
                 # "normal" assigmend
                 push!(body, :($lhs = $wrapped_rhs))
@@ -485,13 +496,15 @@ function _formula_macro(type, ex)
 
     # Generate pretty print string
     s = "    " * join(string.(body), "\n    ")
-    s = replace(s, "(\$(Expr(:escape, :$out_var)))" => "out")
-    s = replace(s, "(\$(Expr(:escape, :$u)))" => "u")
+    s = replace(s, string(out_var) => "out")
+    s = replace(s, string(u) => "u")
     s = "$(type)($output_syms, $input_syms) do out, u\n" * s * "\nend"
+
+    body_esc = _escape_all.(body)
 
     quote
         $(type)($output_syms, $input_syms, $s) do $(esc(out_var)), $(esc(u))
-            $(body...)
+            $(body_esc...)
             nothing
         end
     end

--- a/src/linear_analysis_base.jl
+++ b/src/linear_analysis_base.jl
@@ -46,6 +46,7 @@ See also: [`linearize_network`](@ref), [`reduce_dae`](@ref)
                 throw(ArgumentError("D must have same number of rows as C and same number of columns as B"))
             end
             _nsym(s::SymbolicIndex) = 1
+            _nsym(s::Symbol) = 1
             _nsym(s) = length(s)
             if _nsym(insym) != size(B, 2)
                 throw(ArgumentError("Length of insym must match number of columns in B"))

--- a/test/initialization_test.jl
+++ b/test/initialization_test.jl
@@ -362,6 +362,19 @@ end
     ic1(out1, u)
     ic2(out2, u)
     @test out1 == out2
+
+    # test with capture of runtime variables
+    _zval = 3.0
+    ic3 = @initconstraint begin
+        :x + :y
+        :z^2 - _zval
+    end
+    @test ic3.sym == [:x, :y, :z]
+    out3 = [0.0, 0.0]
+    ic3(out3, [1.0, 2.0, 4.0])
+    @test out3[1] ≈ 3.0
+    @test out3[2] ≈ 4.0^2 - _zval
+    @test !occursin("Expr(:escape", repr(ic3))
 end
 
 @testset "InitConstraint combining constructor" begin
@@ -647,6 +660,20 @@ end
 
         @test out[:Vset] ≈ sqrt(1.0^2 + 2.0^2)
         @test out[:Pset] ≈ 1.0 * 3.0 + 2.0 * 4.0
+
+        # test with capture of runtim variables
+        _vset = 1.0
+        _pset = 2.0
+        if3 = @initformula begin
+            :Vset = _vset^2
+            :Pset = sin(_pset)
+        end
+
+        out = Dict{Symbol,Float64}()
+        u_view = NetworkDynamics.SymbolicView([], Symbol[])
+        if3(out, u_view)
+        @test out[:Vset] == _vset^2
+        @test out[:Pset] == sin(_pset)
     end
 
     @testset "InitFormula with complex expressions" begin
@@ -735,6 +762,22 @@ end
 
         @test out[:Vset] ≈ sqrt(1.0^2 + 2.0^2)
         @test out[:Pset] ≈ 1.0 * 3.0 + 2.0 * 4.0
+
+        # test with capture of runtime variables
+        _vset = 1.0
+        _pset = 2.0
+        gf3 = @guessformula begin
+            :Vset = _vset^2
+            :Pset = sin(_pset)
+        end
+        @test gf3.outsym == [:Vset, :Pset]
+        @test gf3.sym == Symbol[]
+        out = Dict{Symbol,Float64}()
+        u_view = NetworkDynamics.SymbolicView([], Symbol[])
+        gf3(out, u_view)
+        @test out[:Vset] == _vset^2
+        @test out[:Pset] == sin(_pset)
+        @test !occursin("Expr(:escape", repr(gf3))
     end
 
     @testset "GuessFormula validation - KEY DIFFERENCE from InitFormula" begin


### PR DESCRIPTION
Without this PR, referencing runtime symbols in `@initformula`/`@initconstraint` macros fails
```julia
    _zval = 3.0
    ic3 = @initconstraint begin
        :x + :y
        :z^2 - _zval
    end
 ```
because we did not escape `_zval`. Now every symbol in macro scope is escaped. Xref https://github.com/JuliaEnergy/PowerDynamics.jl/issues/266

[no benchmark]