### PR TITLE
add `ParameterScope` variable metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@
   - The default initial state for fixpoint search now applies guesses and formulas automatically (`guess=true, apply_formulas=true`).
 - **`NWState` constructor** gains `guess`, `apply_formulas`, and `verbose` keyword arguments. With `default=true` (the default), values are filled in order: defaults/inits → `InitFormula`s → guesses (if `guess=true`) → `GuessFormula`s. `apply_formulas=true` by default; `guess=false` by default.
 - `doctor` check: added smoketest for the observable function (`obsf`) of each component.
+- **Parameter `scope` metadata**: new `VariableScope` symbol metadata to mark (parameter) variables as `:local`, `:device`, or `:global`.
+  - Usable in `@mtkmodel`/`@component` definitions (e.g. `@parameters p [scope=:global]`) and accessible on the component level via `has_scope`/`get_scope`/`set_scope!`/`delete_scope!`/`strip_scopes!`.
+  - New `chk_global_parameters(nw_or_state_or_param)` checks that scoped parameters are consistent: `:global` parameters (grouped by trailing symbol name, `r"NAME$"`) must agree across the whole network, `:device` parameters within a single component; `:local` is ignored. For `Network` defaults are compared, for `NWState`/`NWParameter` the current values.
+  - This check runs automatically on `ODEProblem` construction (toggle via `NetworkDynamics.CHECK_GLOBAL_PARAMETERS[]`).
 
 ## v0.10.17 Changelog
 - **Open-loop linearization** ([#341](https://github.com/JuliaDynamics/NetworkDynamics.jl/pull/341)):

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
   - The default initial state for fixpoint search now applies guesses and formulas automatically (`guess=true, apply_formulas=true`).
 - **`NWState` constructor** gains `guess`, `apply_formulas`, and `verbose` keyword arguments. With `default=true` (the default), values are filled in order: defaults/inits → `InitFormula`s → guesses (if `guess=true`) → `GuessFormula`s. `apply_formulas=true` by default; `guess=false` by default.
 - `doctor` check: added smoketest for the observable function (`obsf`) of each component.
-- **Parameter `scope` metadata**: new `VariableScope` symbol metadata to mark (parameter) variables as `:local`, `:device`, or `:global`.
+- **Parameter `scope` metadata**: new `ParameterScope` symbol metadata to mark (parameter) variables as `:local`, `:device`, or `:global`.
   - Usable in `@mtkmodel`/`@component` definitions (e.g. `@parameters p [scope=:global]`) and accessible on the component level via `has_scope`/`get_scope`/`set_scope!`/`delete_scope!`/`strip_scopes!`.
   - New `chk_global_parameters(nw_or_state_or_param)` checks that scoped parameters are consistent: `:global` parameters (grouped by trailing symbol name, `r"NAME$"`) must agree across the whole network, `:device` parameters within a single component; `:local` is ignored. For `Network` defaults are compared, for `NWState`/`NWParameter` the current values.
   - This check runs automatically on `ODEProblem` construction (toggle via `NetworkDynamics.CHECK_GLOBAL_PARAMETERS[]`).

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -153,6 +153,12 @@ get_bounds
 set_bounds!
 delete_bounds!
 strip_bounds!
+has_scope
+get_scope
+set_scope!
+delete_scope!
+strip_scopes!
+VariableScope
 set_defaults!
 set_interface_defaults!
 get_defaults_dict
@@ -170,6 +176,7 @@ dump_initial_state
 get_initial_state
 describe_vertices
 describe_edges
+chk_global_parameters
 ```
 
 ## Initialization

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -158,7 +158,7 @@ get_scope
 set_scope!
 delete_scope!
 strip_scopes!
-VariableScope
+ParameterScope
 set_defaults!
 set_interface_defaults!
 get_defaults_dict

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -30,14 +30,14 @@ Special cases for symbol metadata are:
 - `guess`: Stores a guess for a state/parameter which needs to be solved during initialization ("free" variables).
 - `bounds`: Stores bounds for variables/parameters
 - `init`: Stores the solution of the "free" variables, this is rarely set manually but instead when calling [`initialize_component!`](@ref).
-- `scope`: Marks the [`VariableScope`](@ref) of a (parameter) variable as `:local`, `:device` or `:global`. See [Parameter Scope](@ref) below.
+- `scope`: Marks the [`ParameterScope`](@ref) of a (parameter) variable as `:local`, `:device` or `:global`. See [Parameter Scope](@ref) below.
 
 For those, there are special functions `has_*`, `get_*`, `set_*!`, `delete_*!` and `strip_*!`. The `strip_*!` functions remove all metadata of a specific type from all symbols in a component. See [Per Symbol Metadata API](@ref).
 
 These are closely aligned with the [metadata use in ModelingToolkit](@extref ModelingToolkit symbolic_metadata). They are automatically copied from the `System` if you use MTK models to create NetworkDynamics models.
 
 ## Parameter Scope
-The [`VariableScope`](@ref) metadata (`scope`) declares on which level a parameter is expected to be consistent:
+The [`ParameterScope`](@ref) metadata (`scope`) declares on which level a parameter is expected to be consistent:
 
 - `:local` (default): the parameter is purely local to the component and is not checked.
 - `:device`: the parameter must be consistent **within a single** [`VertexModel`](@ref)/[`EdgeModel`](@ref) (e.g. across its subcomponents).

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -30,10 +30,30 @@ Special cases for symbol metadata are:
 - `guess`: Stores a guess for a state/parameter which needs to be solved during initialization ("free" variables).
 - `bounds`: Stores bounds for variables/parameters
 - `init`: Stores the solution of the "free" variables, this is rarely set manually but instead when calling [`initialize_component!`](@ref).
+- `scope`: Marks the [`VariableScope`](@ref) of a (parameter) variable as `:local`, `:device` or `:global`. See [Parameter Scope](@ref) below.
 
 For those, there are special functions `has_*`, `get_*`, `set_*!`, `delete_*!` and `strip_*!`. The `strip_*!` functions remove all metadata of a specific type from all symbols in a component. See [Per Symbol Metadata API](@ref).
 
 These are closely aligned with the [metadata use in ModelingToolkit](@extref ModelingToolkit symbolic_metadata). They are automatically copied from the `System` if you use MTK models to create NetworkDynamics models.
+
+## Parameter Scope
+The [`VariableScope`](@ref) metadata (`scope`) declares on which level a parameter is expected to be consistent:
+
+- `:local` (default): the parameter is purely local to the component and is not checked.
+- `:device`: the parameter must be consistent **within a single** [`VertexModel`](@ref)/[`EdgeModel`](@ref) (e.g. across its subcomponents).
+- `:global`: the parameter must be consistent **across the whole network**, i.e. all parameters sharing the same trailing symbol name (matching `r"NAME$"`) must hold the same value.
+
+In `@mtkmodel`/`@component` style definitions the scope can be attached as variable metadata and is automatically copied to the component:
+
+```julia
+@parameters begin
+    Sbase = 100, [scope = :global]
+end
+```
+
+On the component level it can also be set manually using [`set_scope!`](@ref) (and queried via [`get_scope`](@ref)).
+
+Consistency of scoped parameters can be checked with [`chk_global_parameters`](@ref), which accepts a [`Network`](@ref), [`NWState`](@ref) or [`NWParameter`](@ref). For a `Network` the metadata **defaults** are compared, for `NWState`/`NWParameter` the **current values**. This check also runs automatically on `ODEProblem` construction and can be toggled via `NetworkDynamics.CHECK_GLOBAL_PARAMETERS[]`.
 
 ## Metadata Utils
 Accessing metadata (especially defaults) of states and parameters is a very

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -53,6 +53,8 @@ end
 
 On the component level it can also be set manually using [`set_scope!`](@ref) (and queried via [`get_scope`](@ref)).
 
+If the same trailing name is declared with **different** scopes (for example `:global` on one parameter and `:component` or `:local` on another sharing the name), each scope is checked independently — values are never compared across scopes — and a warning is emitted, since this is almost always a mistake.
+
 Consistency of scoped parameters can be checked with [`chk_global_parameters`](@ref), which accepts a [`Network`](@ref), [`NWState`](@ref) or [`NWParameter`](@ref). For a `Network` the metadata **defaults** are compared, for `NWState`/`NWParameter` the **current values**. This check also runs automatically on `ODEProblem` construction and can be toggled via `NetworkDynamics.CHECK_GLOBAL_PARAMETERS[]`.
 
 ## Metadata Utils

--- a/docs/src/metadata.md
+++ b/docs/src/metadata.md
@@ -30,7 +30,7 @@ Special cases for symbol metadata are:
 - `guess`: Stores a guess for a state/parameter which needs to be solved during initialization ("free" variables).
 - `bounds`: Stores bounds for variables/parameters
 - `init`: Stores the solution of the "free" variables, this is rarely set manually but instead when calling [`initialize_component!`](@ref).
-- `scope`: Marks the [`ParameterScope`](@ref) of a (parameter) variable as `:local`, `:device` or `:global`. See [Parameter Scope](@ref) below.
+- `scope`: Marks the [`ParameterScope`](@ref) of a (parameter) variable as `:local`, `:component` or `:global`. See [Parameter Scope](@ref) below.
 
 For those, there are special functions `has_*`, `get_*`, `set_*!`, `delete_*!` and `strip_*!`. The `strip_*!` functions remove all metadata of a specific type from all symbols in a component. See [Per Symbol Metadata API](@ref).
 
@@ -40,7 +40,7 @@ These are closely aligned with the [metadata use in ModelingToolkit](@extref Mod
 The [`ParameterScope`](@ref) metadata (`scope`) declares on which level a parameter is expected to be consistent:
 
 - `:local` (default): the parameter is purely local to the component and is not checked.
-- `:device`: the parameter must be consistent **within a single** [`VertexModel`](@ref)/[`EdgeModel`](@ref) (e.g. across its subcomponents).
+- `:component`: the parameter must be consistent **within a single** [`VertexModel`](@ref)/[`EdgeModel`](@ref) (e.g. across its subcomponents).
 - `:global`: the parameter must be consistent **across the whole network**, i.e. all parameters sharing the same trailing symbol name (matching `r"NAME$"`) must hold the same value.
 
 In `@mtkmodel`/`@component` style definitions the scope can be attached as variable metadata and is automatically copied to the component:

--- a/ext/NetworkDynamicsMTKExt.jl
+++ b/ext/NetworkDynamicsMTKExt.jl
@@ -330,6 +330,12 @@ function _get_metadata(sys, name, alldefaults, allguesses)
     if ModelingToolkitBase.hasdescription(sym)
         md[:description] = ModelingToolkitBase.getdescription(sym)
     end
+    scope = Symbolics.getmetadata(unwrap(sym), NetworkDynamics.VariableScope, nothing)
+    if !isnothing(scope)
+        # in @mtkmodel definitions symbol-valued metadata is stored unevaluated,
+        # e.g. `[scope = :global]` ends up as a `QuoteNode(:global)`
+        md[:scope] = scope isa QuoteNode ? scope.value : scope
+    end
     md
 end
 

--- a/ext/NetworkDynamicsMTKExt.jl
+++ b/ext/NetworkDynamicsMTKExt.jl
@@ -330,7 +330,7 @@ function _get_metadata(sys, name, alldefaults, allguesses)
     if ModelingToolkitBase.hasdescription(sym)
         md[:description] = ModelingToolkitBase.getdescription(sym)
     end
-    scope = Symbolics.getmetadata(unwrap(sym), NetworkDynamics.VariableScope, nothing)
+    scope = Symbolics.getmetadata(unwrap(sym), NetworkDynamics.ParameterScope, nothing)
     if !isnothing(scope)
         # in @mtkmodel definitions symbol-valued metadata is stored unevaluated,
         # e.g. `[scope = :global]` ends up as a `QuoteNode(:global)`

--- a/ext/NetworkDynamicsSymbolicsExt.jl
+++ b/ext/NetworkDynamicsSymbolicsExt.jl
@@ -2,12 +2,12 @@ module NetworkDynamicsSymbolicsExt
 
 using Symbolics: Symbolics, @variables
 using MacroTools: postwalk, @capture
-using NetworkDynamics: NetworkDynamics, SymbolicIndex, SII, VariableScope
+using NetworkDynamics: NetworkDynamics, SymbolicIndex, SII, ParameterScope
 
 # Register `scope` as symbolic variable metadata, so that it can be used in
 # `@variables`/`@parameters`/`@mtkmodel`/`@component` style definitions, e.g.
 # `@parameters p [scope=:global]`.
-Symbolics.option_to_metadata_type(::Val{:scope}) = VariableScope
+Symbolics.option_to_metadata_type(::Val{:scope}) = ParameterScope
 
 function NetworkDynamics.generate_observable_expression(ex::Expr)
     if @capture(ex, capname_ = capcontent_)

--- a/ext/NetworkDynamicsSymbolicsExt.jl
+++ b/ext/NetworkDynamicsSymbolicsExt.jl
@@ -2,7 +2,12 @@ module NetworkDynamicsSymbolicsExt
 
 using Symbolics: Symbolics, @variables
 using MacroTools: postwalk, @capture
-using NetworkDynamics: NetworkDynamics, SymbolicIndex, SII
+using NetworkDynamics: NetworkDynamics, SymbolicIndex, SII, VariableScope
+
+# Register `scope` as symbolic variable metadata, so that it can be used in
+# `@variables`/`@parameters`/`@mtkmodel`/`@component` style definitions, e.g.
+# `@parameters p [scope=:global]`.
+Symbolics.option_to_metadata_type(::Val{:scope}) = VariableScope
 
 function NetworkDynamics.generate_observable_expression(ex::Expr)
     if @capture(ex, capname_ = capcontent_)

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -106,6 +106,8 @@ export has_default, get_default, set_default!, delete_default!, set_defaults!, s
 export has_guess, get_guess, set_guess!, delete_guess!, strip_guesses!
 export has_init, get_init, set_init!, delete_init!, strip_inits!
 export has_bounds, get_bounds, set_bounds!, delete_bounds!, strip_bounds!
+export has_scope, get_scope, set_scope!, delete_scope!, strip_scopes!
+export VariableScope
 export has_graphelement, get_graphelement, set_graphelement!
 export get_initial_state, dump_initial_state, dump_state
 export has_callback, get_callbacks, set_callback!, add_callback!, delete_callbacks!
@@ -128,7 +130,9 @@ include("linear_analysis.jl")
 include("show.jl")
 
 const CHECK_COMPONENT = Ref(true)
-export chk_component
+# controls whether `chk_global_parameters` is run automatically on ODEProblem construction
+const CHECK_GLOBAL_PARAMETERS = Ref(true)
+export chk_component, chk_global_parameters
 include("doctor.jl")
 
 # additional utils, which depend on specific types beeing defined so they should be

--- a/src/NetworkDynamics.jl
+++ b/src/NetworkDynamics.jl
@@ -107,7 +107,7 @@ export has_guess, get_guess, set_guess!, delete_guess!, strip_guesses!
 export has_init, get_init, set_init!, delete_init!, strip_inits!
 export has_bounds, get_bounds, set_bounds!, delete_bounds!, strip_bounds!
 export has_scope, get_scope, set_scope!, delete_scope!, strip_scopes!
-export VariableScope
+export ParameterScope
 export has_graphelement, get_graphelement, set_graphelement!
 export get_initial_state, dump_initial_state, dump_state
 export has_callback, get_callbacks, set_callback!, add_callback!, delete_callbacks!

--- a/src/construction.jl
+++ b/src/construction.jl
@@ -38,12 +38,16 @@ function Network(g::AbstractGraph,
                  verbose=false)
     # TimerOutputs.reset_timer!()
     @timeit_debug "Construct Network" begin
-        # collect all vertex/edgf to vector
-        all_same_v = vertexm isa VertexModel
-        all_same_e = edgem isa EdgeModel
+        # collect all vertex/edge models to a vector
+        single_v = vertexm isa VertexModel
+        single_e = edgem isa EdgeModel
+        # a single model backing only a single graph element is not an alias: the
+        # instance is referenced exactly once, so mutating its metadata is safe.
+        all_same_v = single_v && nv(g) > 1
+        all_same_e = single_e && ne(g) > 1
         maybecopy = dealias ? copy : identity
-        _vertexm = all_same_v ? [maybecopy(vertexm) for _ in vertices(g)] : vertexm
-        _edgem   = all_same_e ? [maybecopy(edgem) for _ in edges(g)] : edgem
+        _vertexm = single_v ? [maybecopy(vertexm) for _ in vertices(g)] : vertexm
+        _edgem   = single_e ? [maybecopy(edgem) for _ in edges(g)] : edgem
 
         @argcheck _vertexm isa Vector{<:VertexModel} "Expected VertexModels, got $(eltype(_vertexm))"
         @argcheck _edgem isa Vector{<:EdgeModel} "Expected EdgeModels, got $(eltype(_vertexm))"

--- a/src/doctor.jl
+++ b/src/doctor.jl
@@ -199,7 +199,7 @@ _scope_basename(sym) = Symbol(last(split(string(sym), '₊')))
     chk_global_parameters(s::NWState; verbose=true)
     chk_global_parameters(p::NWParameter; verbose=true)
 
-Check the consistency of *scoped* parameters (see [`VariableScope`](@ref)).
+Check the consistency of *scoped* parameters (see [`ParameterScope`](@ref)).
 
 Parameters are grouped by the trailing part of their symbol name (matching
 `r"NAME\$"`):
@@ -216,7 +216,7 @@ For a `Network` the metadata **defaults** are compared. For an `NWState`/
 Returns `true` if all scoped parameters are consistent, `false` otherwise. When
 `verbose=true` (the default) a warning describing each inconsistency is emitted.
 
-See also: [`VariableScope`](@ref), [`get_scope`](@ref).
+See also: [`ParameterScope`](@ref), [`get_scope`](@ref).
 """
 function chk_global_parameters end
 

--- a/src/doctor.jl
+++ b/src/doctor.jl
@@ -206,7 +206,7 @@ Parameters are grouped by the trailing part of their symbol name (matching
 
 - parameters with scope `:global` must hold the same value across the **whole
   network**,
-- parameters with scope `:device` must hold the same value **within a single**
+- parameters with scope `:component` must hold the same value **within a single**
   `VertexModel`/`EdgeModel`,
 - parameters with scope `:local` are ignored.
 
@@ -248,8 +248,8 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
                 end
             end
         end
-        # device groups are local to this single component
-        devicegroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
+        # component groups are local to this single component
+        componentgroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
         for s in psym(c)
             has_scope(c, s) || continue
             scope = get_scope(c, s)
@@ -260,14 +260,14 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
             loc = "$prefix$ci :$s"
             if scope == :global
                 push!(get!(globalgroups, base, Pair{Any,String}[]), val => loc)
-            elseif scope == :device
-                push!(get!(devicegroups, base, Pair{Any,String}[]), val => loc)
+            elseif scope == :component
+                push!(get!(componentgroups, base, Pair{Any,String}[]), val => loc)
             else
-                throw(ArgumentError("Unknown scope $(repr(scope)) for $loc. Must be :local, :device or :global."))
+                throw(ArgumentError("Unknown scope $(repr(scope)) for $loc. Must be :local, :component or :global."))
             end
         end
-        for (base, entries) in devicegroups
-            ok &= _chk_consistent_scope("device parameter :$base ($prefix$ci)", entries, verbose)
+        for (base, entries) in componentgroups
+            ok &= _chk_consistent_scope("component parameter :$base ($prefix$ci)", entries, verbose)
         end
     end
 

--- a/src/doctor.jl
+++ b/src/doctor.jl
@@ -186,3 +186,98 @@ end
 
 _ninout(::EdgeModel) = 2
 _ninout(::VertexModel) = 1
+
+####
+#### scope consistency checks
+####
+# basename used for grouping scoped parameters: the trailing part of the symbol
+# name after the last namespace separator `₊`, i.e. matching `r"NAME$"`.
+_scope_basename(sym) = Symbol(last(split(string(sym), '₊')))
+
+"""
+    chk_global_parameters(nw::Network; verbose=true)
+    chk_global_parameters(s::NWState; verbose=true)
+    chk_global_parameters(p::NWParameter; verbose=true)
+
+Check the consistency of *scoped* parameters (see [`VariableScope`](@ref)).
+
+Parameters are grouped by the trailing part of their symbol name (matching
+`r"NAME\$"`):
+
+- parameters with scope `:global` must hold the same value across the **whole
+  network**,
+- parameters with scope `:device` must hold the same value **within a single**
+  `VertexModel`/`EdgeModel`,
+- parameters with scope `:local` are ignored.
+
+For a `Network` the metadata **defaults** are compared. For an `NWState`/
+`NWParameter` the **current values** in the flat parameter array are compared.
+
+Returns `true` if all scoped parameters are consistent, `false` otherwise. When
+`verbose=true` (the default) a warning describing each inconsistency is emitted.
+
+See also: [`VariableScope`](@ref), [`get_scope`](@ref).
+"""
+function chk_global_parameters end
+
+chk_global_parameters(nw::Network; kw...) = _chk_global_parameters(nw, nothing; kw...)
+chk_global_parameters(p::NWParameter; kw...) = _chk_global_parameters(p.nw, p; kw...)
+chk_global_parameters(s::NWState; kw...) = _chk_global_parameters(s.nw, s.p; kw...)
+
+function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
+    # value getter for a parameter `sym` of component `c` at index `ci` (idxtype VIndex/EIndex)
+    getval = if isnothing(valueprovider)
+        (idxtype, ci, c, sym) -> has_default(c, sym) ? get_default(c, sym) : nothing
+    else
+        (idxtype, ci, c, sym) -> valueprovider[idxtype(ci, sym)]
+    end
+
+    ok = true
+    # global groups span the whole network: basename => Vector{Pair{value, location}}
+    globalgroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
+
+    function _handle(c, ci, idxtype, prefix)
+        # device groups are local to this single component
+        devicegroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
+        for s in psym(c)
+            has_scope(c, s) || continue
+            scope = get_scope(c, s)
+            scope == :local && continue
+            val = getval(idxtype, ci, c, s)
+            isnothing(val) && continue
+            base = _scope_basename(s)
+            loc = "$prefix$ci :$s"
+            if scope == :global
+                push!(get!(globalgroups, base, Pair{Any,String}[]), val => loc)
+            elseif scope == :device
+                push!(get!(devicegroups, base, Pair{Any,String}[]), val => loc)
+            else
+                throw(ArgumentError("Unknown scope $(repr(scope)) for $loc. Must be :local, :device or :global."))
+            end
+        end
+        for (base, entries) in devicegroups
+            ok &= _chk_consistent_scope("device parameter :$base ($prefix$ci)", entries, verbose)
+        end
+    end
+
+    for (ci, c) in pairs(nw.im.vertexm)
+        _handle(c, ci, VIndex, "VIndex ")
+    end
+    for (ci, c) in pairs(nw.im.edgem)
+        _handle(c, ci, EIndex, "EIndex ")
+    end
+    for (base, entries) in globalgroups
+        ok &= _chk_consistent_scope("global parameter :$base", entries, verbose)
+    end
+    ok
+end
+
+function _chk_consistent_scope(desc, entries, verbose)
+    vals = unique(first.(entries))
+    length(vals) <= 1 && return true
+    if verbose
+        msg = "Inconsistent $desc:\n" * join(("  $loc = $val" for (val, loc) in entries), "\n")
+        @warn msg
+    end
+    false
+end

--- a/src/doctor.jl
+++ b/src/doctor.jl
@@ -210,6 +210,11 @@ Parameters are grouped by the trailing part of their symbol name (matching
   `VertexModel`/`EdgeModel`,
 - parameters with scope `:local` are ignored.
 
+If the same basename is declared with **different** scopes (e.g. `:global` in
+one place and `:component` or `:local` in another), the scopes are still checked
+independently — values are never compared *across* scopes — but a warning is
+emitted because this is almost always unintended.
+
 For a `Network` the metadata **defaults** are compared. For an `NWState`/
 `NWParameter` the **current values** in the flat parameter array are compared.
 
@@ -235,6 +240,9 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
     ok = true
     # global groups span the whole network: basename => Vector{Pair{value, location}}
     globalgroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
+    # network-wide effective scope per basename, used to detect names that are
+    # declared with conflicting scopes: basename => (scope => Vector{location})
+    networkscopes = OrderedDict{Symbol, OrderedDict{Symbol, Vector{String}}}()
 
     function _handle(c, ci, idxtype, prefix)
         # scope is only meaningful (and enforced) for parameters; warn if it was
@@ -250,14 +258,18 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
         end
         # component groups are local to this single component
         componentgroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
+        # per-component effective scope per basename (mirror of `networkscopes`)
+        componentscopes = OrderedDict{Symbol, OrderedDict{Symbol, Vector{String}}}()
         for s in psym(c)
-            has_scope(c, s) || continue
-            scope = get_scope(c, s)
+            # effective scope defaults to `:local` when no scope metadata is set
+            scope = has_scope(c, s) ? get_scope(c, s) : :local
+            base = _scope_basename(s)
+            loc = "$prefix$ci :$s"
+            _record_scope!(componentscopes, base, scope, loc)
+            _record_scope!(networkscopes, base, scope, loc)
             scope == :local && continue
             val = getval(idxtype, ci, c, s)
             isnothing(val) && continue
-            base = _scope_basename(s)
-            loc = "$prefix$ci :$s"
             if scope == :global
                 push!(get!(globalgroups, base, Pair{Any,String}[]), val => loc)
             elseif scope == :component
@@ -269,6 +281,9 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
         for (base, entries) in componentgroups
             ok &= _chk_consistent_scope("component parameter :$base ($prefix$ci)", entries, verbose)
         end
+        # warn about names that are `:component`-scoped here but carry a different
+        # scope on another parameter of the *same component*
+        verbose && _warn_mixed_scopes(componentscopes, :component, "within $prefix$ci")
     end
 
     for (ci, c) in pairs(nw.im.vertexm)
@@ -280,7 +295,30 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
     for (base, entries) in globalgroups
         ok &= _chk_consistent_scope("global parameter :$base", entries, verbose)
     end
+    # warn about names that are `:global`-scoped somewhere but carry a different
+    # scope on another parameter *anywhere in the network*
+    verbose && _warn_mixed_scopes(networkscopes, :global, "across the network")
     ok
+end
+
+# record the effective `scope` of `loc` under `base` into the nested scope map
+function _record_scope!(scopemap, base, scope, loc)
+    byscope = get!(scopemap, base, OrderedDict{Symbol, Vector{String}}())
+    push!(get!(byscope, scope, String[]), loc)
+end
+
+# Warn when a basename is declared with `scope` *and* at least one different scope
+# in `scopemap`. Such names are almost certainly a mistake: the scope buckets are
+# checked independently and are never compared against each other.
+function _warn_mixed_scopes(scopemap, scope, where)
+    for (base, byscope) in scopemap
+        haskey(byscope, scope) || continue
+        length(byscope) <= 1 && continue
+        locs = ["  $loc => $sc" for (sc, ls) in byscope for loc in ls]
+        @warn "Parameter :$base is declared with mixed scopes $where; \
+               each scope is checked independently and the values are not \
+               compared across scopes:\n" * join(locs, "\n")
+    end
 end
 
 function _chk_consistent_scope(desc, entries, verbose)

--- a/src/doctor.jl
+++ b/src/doctor.jl
@@ -237,6 +237,17 @@ function _chk_global_parameters(nw::Network, valueprovider; verbose=true)
     globalgroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
 
     function _handle(c, ci, idxtype, prefix)
+        # scope is only meaningful (and enforced) for parameters; warn if it was
+        # accidentally attached to a state/observable/input/output symbol
+        if verbose
+            pset = Set(psym(c))
+            for (s, smd) in symmetadata(c)
+                if haskey(smd, :scope) && s ∉ pset
+                    @warn "Symbol :$s in $prefix$ci carries `:scope` metadata but is not a parameter. \
+                           Scope is only enforced for parameters and is ignored here."
+                end
+            end
+        end
         # device groups are local to this single component
         devicegroups = OrderedDict{Symbol, Vector{Pair{Any,String}}}()
         for s in psym(c)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -164,8 +164,33 @@ function strip_metadata!(c::ComponentModel, key::Symbol)
 end
 strip_metadata!(nw::Network, sym::SymbolicIndex, key::Symbol) = strip_metadata!(getcomp(nw, sym), key)
 
+"""
+    VariableScope
+
+Symbolic metadata type for specifying the *scope* of a (parameter) variable. The
+scope determines on which level a parameter is expected to be consistent and is
+one of:
+
+- `:local` (default): the parameter is purely local to the component and is not
+  checked for consistency.
+- `:device`: the parameter is expected to be consistent within a single
+  `VertexModel`/`EdgeModel` (e.g. across its subcomponents).
+- `:global`: the parameter is expected to be consistent across the whole network,
+  i.e. all parameters sharing the same (trailing) symbol name must hold the same
+  value.
+
+In `@mtkmodel`/`@component` style definitions the scope can be attached as
+variable metadata, e.g. `@parameters p [scope=:global]`. On the
+`VertexModel`/`EdgeModel` level it is stored as the `:scope` symbol metadata and
+can be accessed using [`get_scope`](@ref)/[`set_scope!`](@ref).
+
+Consistency of scoped parameters can be checked using
+[`chk_global_parameters`](@ref).
+"""
+struct VariableScope end
+
 # generate default methods for some per-symbol metadata fields
-for md in [:default, :guess, :init, :bounds]
+for md in [:default, :guess, :init, :bounds, :scope]
     fname_has = Symbol(:has_, md)
     fname_get = Symbol(:get_, md)
     fname_set = Symbol(:set_, md, :!)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -173,7 +173,7 @@ one of:
 
 - `:local` (default): the parameter is purely local to the component and is not
   checked for consistency.
-- `:device`: the parameter is expected to be consistent within a single
+- `:component`: the parameter is expected to be consistent within a single
   `VertexModel`/`EdgeModel` (e.g. across its subcomponents).
 - `:global`: the parameter is expected to be consistent across the whole network,
   i.e. all parameters sharing the same (trailing) symbol name must hold the same

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -165,7 +165,7 @@ end
 strip_metadata!(nw::Network, sym::SymbolicIndex, key::Symbol) = strip_metadata!(getcomp(nw, sym), key)
 
 """
-    VariableScope
+    ParameterScope
 
 Symbolic metadata type for specifying the *scope* of a (parameter) variable. The
 scope determines on which level a parameter is expected to be consistent and is
@@ -187,7 +187,7 @@ can be accessed using [`get_scope`](@ref)/[`set_scope!`](@ref).
 Consistency of scoped parameters can be checked using
 [`chk_global_parameters`](@ref).
 """
-struct VariableScope end
+struct ParameterScope end
 
 # generate default methods for some per-symbol metadata fields
 for md in [:default, :guess, :init, :bounds, :scope]

--- a/src/post_utils.jl
+++ b/src/post_utils.jl
@@ -73,7 +73,7 @@ function SciMLBase.ODEProblem(
     prob = SciMLBase.ODEProblem(SciMLBase.ODEFunction(nw), args...; callback=finalcallback, kwargs...)
 
     # at this point all parameters are known, so we can check the consistency of
-    # scoped (`:global`/`:device`) parameters, see `chk_global_parameters`
+    # scoped (`:global`/`:component`) parameters, see `chk_global_parameters`
     if CHECK_GLOBAL_PARAMETERS[] && prob.p isa AbstractVector && length(prob.p) == pdim(nw)
         chk_global_parameters(NWParameter(nw, prob.p))
     end

--- a/src/post_utils.jl
+++ b/src/post_utils.jl
@@ -70,7 +70,15 @@ function SciMLBase.ODEProblem(
         end
     end
 
-    SciMLBase.ODEProblem(SciMLBase.ODEFunction(nw), args...; callback=finalcallback, kwargs...)
+    prob = SciMLBase.ODEProblem(SciMLBase.ODEFunction(nw), args...; callback=finalcallback, kwargs...)
+
+    # at this point all parameters are known, so we can check the consistency of
+    # scoped (`:global`/`:device`) parameters, see `chk_global_parameters`
+    if CHECK_GLOBAL_PARAMETERS[] && prob.p isa AbstractVector && length(prob.p) == pdim(nw)
+        chk_global_parameters(NWParameter(nw, prob.p))
+    end
+
+    prob
 end
 
 """

--- a/test/global_paramcheck.jl
+++ b/test/global_paramcheck.jl
@@ -1,0 +1,186 @@
+using NetworkDynamics
+using ModelingToolkitBase
+using ModelingToolkitBase: t_nounits as t, D_nounits as Dt
+using SciCompDSL
+using Graphs
+using Test
+
+@testset "scope metadata basics" begin
+    # plain VertexModel + set_scope!
+    v = VertexModel(f=(dv, v, esum, p, t) -> (dv[1] = 0.0), g=1,
+                    sym=[:x => 0.0], psym=[:Vbase => 1.0], name=:plainv)
+    @test !has_scope(v, :Vbase)
+    set_scope!(v, :Vbase, :global)
+    @test has_scope(v, :Vbase)
+    @test get_scope(v, :Vbase) == :global
+    delete_scope!(v, :Vbase)
+    @test !has_scope(v, :Vbase)
+    set_scope!(v, :Vbase, :global)
+    strip_scopes!(v)
+    @test !has_scope(v, :Vbase)
+end
+
+@testset "scope from @mtkmodel definition" begin
+    @mtkmodel ScopedNode begin
+        @variables begin
+            θ(t) = 0.0, [output = true]
+            P(t), [input = true]
+        end
+        @parameters begin
+            Vbase = 1.0, [scope = :global]
+            kp = 2.0, [scope = :device]
+            loc = 3.0
+        end
+        @equations begin
+            Dt(θ) ~ kp * (Vbase + P + loc)
+        end
+    end
+    vm = VertexModel(ScopedNode(name=:scoped), [:P], [:θ])
+
+    @test get_scope(vm, :Vbase) == :global
+    @test get_scope(vm, :kp) == :device
+    @test !has_scope(vm, :loc)
+end
+
+# helper to build a simple vertex with given scoped parameters
+function scopedvertex(name, psympairs, scopes)
+    v = VertexModel(f=(dv, v, esum, p, t) -> (dv[1] = 0.0), g=1,
+                    sym=[:x => 0.0], psym=psympairs, name=name)
+    for (s, sc) in scopes
+        set_scope!(v, s, sc)
+    end
+    v
+end
+
+@testset "global scope consistency on Network" begin
+    g = path_graph(2)
+    v1 = scopedvertex(:v1, [:Vbase => 1.0, :loc => 5.0], [:Vbase => :global, :loc => :local])
+    v2 = scopedvertex(:v2, [:Vbase => 1.0, :loc => 7.0], [:Vbase => :global, :loc => :local])
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+
+    nw = Network(g, [v1, v2], e)
+    @test chk_global_parameters(nw) == true
+
+    # make the global parameter inconsistent
+    set_default!(v2, :Vbase, 2.0)
+    nw2 = Network(g, [v1, v2], e)
+    @test (@test_logs (:warn,) chk_global_parameters(nw2)) == false
+    @test chk_global_parameters(nw2; verbose=false) == false
+end
+
+@testset "device scope consistency within component" begin
+    g = path_graph(2)
+    # namespaced parameters sharing the basename `kp`
+    vok = scopedvertex(:vok, [Symbol("a₊kp") => 1.0, Symbol("b₊kp") => 1.0],
+                       [Symbol("a₊kp") => :device, Symbol("b₊kp") => :device])
+    vbad = scopedvertex(:vbad, [Symbol("a₊kp") => 1.0, Symbol("b₊kp") => 9.0],
+                        [Symbol("a₊kp") => :device, Symbol("b₊kp") => :device])
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+
+    nwok = Network(g, [vok, vok], e)
+    @test chk_global_parameters(nwok) == true
+
+    nwbad = Network(g, [vok, vbad], e)
+    @test chk_global_parameters(nwbad; verbose=false) == false
+end
+
+@testset "device scope from @mtkmodel subcomponents" begin
+    # two subcomponents each carrying a device-scoped parameter `kp`, which become
+    # the namespaced parameters `a₊kp` and `b₊kp` on the VertexModel level
+    @mtkmodel DevSub begin
+        @variables begin
+            o(t), [output = true]
+            i(t), [input = true]
+        end
+        @parameters begin
+            kp = 1.0, [scope = :device]
+        end
+        @equations begin
+            o ~ kp * i
+        end
+    end
+    @mtkmodel DevNode begin
+        @components begin
+            a = DevSub()
+            b = DevSub()
+        end
+        @variables begin
+            θ(t) = 0.0, [output = true]
+            P(t), [input = true]
+        end
+        @equations begin
+            a.i ~ P
+            b.i ~ P
+            Dt(θ) ~ a.o + b.o
+        end
+    end
+
+    vmok = VertexModel(DevNode(name=:dev), [:P], [:θ])
+    @test get_scope(vmok, Symbol("a₊kp")) == :device
+    @test get_scope(vmok, Symbol("b₊kp")) == :device
+
+    vmbad = VertexModel(DevNode(name=:dev), [:P], [:θ])
+    set_default!(vmbad, Symbol("b₊kp"), 9.0)
+
+    g = path_graph(2)
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+
+    # consistent device parameters within each component
+    nwok = Network(g, [vmok, vmok], e)
+    @test chk_global_parameters(nwok) == true
+
+    # inconsistent device parameters within the second component
+    nwbad = Network(g, [vmok, vmbad], e)
+    @test chk_global_parameters(nwbad; verbose=false) == false
+
+    # device inconsistency is also caught automatically on ODEProblem construction
+    s0 = NWState(nwbad)
+    s0.v[:, :θ] .= 0.0
+    @test_logs (:warn,) ODEProblem(nwbad, s0, (0.0, 1.0))
+end
+
+@testset "consistency check on NWState / NWParameter (current values)" begin
+    g = path_graph(2)
+    v1 = scopedvertex(:v1, [:Vbase => 1.0], [:Vbase => :global])
+    v2 = scopedvertex(:v2, [:Vbase => 1.0], [:Vbase => :global])
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+    nw = Network(g, [v1, v2], e)
+
+    # defaults are consistent
+    @test chk_global_parameters(nw) == true
+
+    p = NWParameter(nw)
+    @test chk_global_parameters(p) == true
+
+    # tamper the current value of one global parameter
+    p[VIndex(2, :Vbase)] = 42.0
+    @test chk_global_parameters(p; verbose=false) == false
+
+    s = NWState(nw)
+    @test chk_global_parameters(s) == true
+    s.p[VIndex(2, :Vbase)] = 42.0
+    @test chk_global_parameters(s; verbose=false) == false
+end
+
+@testset "automatic check on ODEProblem construction" begin
+    g = path_graph(2)
+    v1 = scopedvertex(:v1, [:Vbase => 1.0], [:Vbase => :global])
+    v2 = scopedvertex(:v2, [:Vbase => 1.0], [:Vbase => :global])
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+    nw = Network(g, [v1, v2], e)
+
+    s0 = NWState(nw)
+    s0.v[:, :x] .= 0.0
+
+    # consistent parameters -> no warning
+    @test_logs ODEProblem(nw, s0, (0.0, 1.0))
+
+    # inconsistent parameters -> warning emitted during construction
+    s0.p[VIndex(2, :Vbase)] = 42.0
+    @test_logs (:warn,) ODEProblem(nw, s0, (0.0, 1.0))
+
+    # check can be disabled globally
+    NetworkDynamics.CHECK_GLOBAL_PARAMETERS[] = false
+    @test_logs ODEProblem(nw, s0, (0.0, 1.0))
+    NetworkDynamics.CHECK_GLOBAL_PARAMETERS[] = true
+end

--- a/test/global_paramcheck.jl
+++ b/test/global_paramcheck.jl
@@ -162,6 +162,20 @@ end
     @test chk_global_parameters(s; verbose=false) == false
 end
 
+@testset "scope on non-parameter symbols warns" begin
+    g = path_graph(2)
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+    v1 = scopedvertex(:v1, [:Vbase => 1.0], [:Vbase => :global])
+    v2 = scopedvertex(:v2, [:Vbase => 1.0], [:Vbase => :global])
+    # attach scope to a *state* symbol, which is meaningless and should warn
+    set_scope!(v1, :x, :global)
+
+    nw = Network(g, [v1, v2], e)
+    @test_logs (:warn,) match_mode = :any chk_global_parameters(nw)
+    # still consistent for the actual parameters
+    @test chk_global_parameters(nw; verbose=false) == true
+end
+
 @testset "automatic check on ODEProblem construction" begin
     g = path_graph(2)
     v1 = scopedvertex(:v1, [:Vbase => 1.0], [:Vbase => :global])

--- a/test/global_paramcheck.jl
+++ b/test/global_paramcheck.jl
@@ -64,7 +64,7 @@ end
     # make the global parameter inconsistent
     set_default!(v2, :Vbase, 2.0)
     nw2 = Network(g, [v1, v2], e)
-    @test (@test_logs (:warn,) chk_global_parameters(nw2)) == false
+    @test (@test_logs (:warn, r"Inconsistent global parameter :Vbase") chk_global_parameters(nw2)) == false
     @test chk_global_parameters(nw2; verbose=false) == false
 end
 
@@ -136,7 +136,9 @@ end
     # component inconsistency is also caught automatically on ODEProblem construction
     s0 = NWState(nwbad)
     s0.v[:, :θ] .= 0.0
-    @test_logs (:warn,) ODEProblem(nwbad, s0, (0.0, 1.0))
+    @test_logs (:warn, r"Inconsistent component parameter :kp") match_mode = :any begin
+        ODEProblem(nwbad, s0, (0.0, 1.0))
+    end
 end
 
 @testset "consistency check on NWState / NWParameter (current values)" begin
@@ -171,9 +173,55 @@ end
     set_scope!(v1, :x, :global)
 
     nw = Network(g, [v1, v2], e)
-    @test_logs (:warn,) match_mode = :any chk_global_parameters(nw)
+    @test_logs (:warn, r"Symbol :x .* not a parameter") match_mode = :any begin
+        chk_global_parameters(nw)
+    end
     # still consistent for the actual parameters
     @test chk_global_parameters(nw; verbose=false) == true
+end
+
+@testset "mixed scopes for the same basename warn" begin
+    e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
+
+    # network-wide collision: `Vbase` is :global on v1 but :local on v2
+    g = path_graph(2)
+    v1 = scopedvertex(:v1, [:Vbase => 1.0], [:Vbase => :global])
+    v2 = scopedvertex(:v2, [:Vbase => 1.0], [:Vbase => :local])
+    nw = Network(g, [v1, v2], e)
+    @test_logs (:warn, r"Vbase.*mixed scopes across the network") match_mode = :any begin
+        chk_global_parameters(nw)
+    end
+    # values are not compared across scopes -> still "consistent"
+    @test chk_global_parameters(nw; verbose=false) == true
+
+    # within-component collision: `a₊kp` is :component but `b₊kp` is :local
+    vmix = scopedvertex(:vmix, [Symbol("a₊kp") => 1.0, Symbol("b₊kp") => 9.0],
+                        [Symbol("a₊kp") => :component, Symbol("b₊kp") => :local])
+    nwc = Network(g, [vmix, vmix], e)
+    @test_logs (:warn, r"kp.*mixed scopes within") match_mode = :any begin
+        chk_global_parameters(nwc)
+    end
+
+    # network-wide collision between :global and :component for the same name
+    vg = scopedvertex(:vg, [:y => 1.0], [:y => :global])
+    vk = scopedvertex(:vk, [:y => 1.0], [:y => :component])
+    nwgk = Network(g, [vg, vk], e)
+    @test_logs (:warn, r"y.*mixed scopes across the network") match_mode = :any begin
+        chk_global_parameters(nwgk)
+    end
+
+    # `:component` here vs `:local` in another vertex is fine -> no warning.
+    # `gx` is :global (uniform), `c` is :component in vca but :local in vcb.
+    vca = scopedvertex(:vca, [:gx => 1.0, :c => 1.0], [:gx => :global, :c => :component])
+    vcb = scopedvertex(:vcb, [:gx => 1.0, :c => 2.0], [:gx => :global, :c => :local])
+    nwcomp = Network(g, [vca, vcb], e)
+    @test_logs chk_global_parameters(nwcomp)
+
+    # uniform scopes -> no mixed-scope warning
+    vu1 = scopedvertex(:vu1, [:Vbase => 1.0], [:Vbase => :global])
+    vu2 = scopedvertex(:vu2, [:Vbase => 1.0], [:Vbase => :global])
+    nwu = Network(g, [vu1, vu2], e)
+    @test_logs chk_global_parameters(nwu)
 end
 
 @testset "automatic check on ODEProblem construction" begin
@@ -191,7 +239,9 @@ end
 
     # inconsistent parameters -> warning emitted during construction
     s0.p[VIndex(2, :Vbase)] = 42.0
-    @test_logs (:warn,) ODEProblem(nw, s0, (0.0, 1.0))
+    @test_logs (:warn, r"Inconsistent global parameter :Vbase") match_mode = :any begin
+        ODEProblem(nw, s0, (0.0, 1.0))
+    end
 
     # check can be disabled globally
     NetworkDynamics.CHECK_GLOBAL_PARAMETERS[] = false

--- a/test/global_paramcheck.jl
+++ b/test/global_paramcheck.jl
@@ -28,7 +28,7 @@ end
         end
         @parameters begin
             Vbase = 1.0, [scope = :global]
-            kp = 2.0, [scope = :device]
+            kp = 2.0, [scope = :component]
             loc = 3.0
         end
         @equations begin
@@ -38,7 +38,7 @@ end
     vm = VertexModel(ScopedNode(name=:scoped), [:P], [:θ])
 
     @test get_scope(vm, :Vbase) == :global
-    @test get_scope(vm, :kp) == :device
+    @test get_scope(vm, :kp) == :component
     @test !has_scope(vm, :loc)
 end
 
@@ -68,13 +68,13 @@ end
     @test chk_global_parameters(nw2; verbose=false) == false
 end
 
-@testset "device scope consistency within component" begin
+@testset "component scope consistency within component" begin
     g = path_graph(2)
     # namespaced parameters sharing the basename `kp`
     vok = scopedvertex(:vok, [Symbol("a₊kp") => 1.0, Symbol("b₊kp") => 1.0],
-                       [Symbol("a₊kp") => :device, Symbol("b₊kp") => :device])
+                       [Symbol("a₊kp") => :component, Symbol("b₊kp") => :component])
     vbad = scopedvertex(:vbad, [Symbol("a₊kp") => 1.0, Symbol("b₊kp") => 9.0],
-                        [Symbol("a₊kp") => :device, Symbol("b₊kp") => :device])
+                        [Symbol("a₊kp") => :component, Symbol("b₊kp") => :component])
     e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
 
     nwok = Network(g, [vok, vok], e)
@@ -84,8 +84,8 @@ end
     @test chk_global_parameters(nwbad; verbose=false) == false
 end
 
-@testset "device scope from @mtkmodel subcomponents" begin
-    # two subcomponents each carrying a device-scoped parameter `kp`, which become
+@testset "component scope from @mtkmodel subcomponents" begin
+    # two subcomponents each carrying a component-scoped parameter `kp`, which become
     # the namespaced parameters `a₊kp` and `b₊kp` on the VertexModel level
     @mtkmodel DevSub begin
         @variables begin
@@ -93,7 +93,7 @@ end
             i(t), [input = true]
         end
         @parameters begin
-            kp = 1.0, [scope = :device]
+            kp = 1.0, [scope = :component]
         end
         @equations begin
             o ~ kp * i
@@ -116,8 +116,8 @@ end
     end
 
     vmok = VertexModel(DevNode(name=:dev), [:P], [:θ])
-    @test get_scope(vmok, Symbol("a₊kp")) == :device
-    @test get_scope(vmok, Symbol("b₊kp")) == :device
+    @test get_scope(vmok, Symbol("a₊kp")) == :component
+    @test get_scope(vmok, Symbol("b₊kp")) == :component
 
     vmbad = VertexModel(DevNode(name=:dev), [:P], [:θ])
     set_default!(vmbad, Symbol("b₊kp"), 9.0)
@@ -125,15 +125,15 @@ end
     g = path_graph(2)
     e = EdgeModel(g=AntiSymmetric((e, vs, vd, p, t) -> (e[1] = 0.0)), outdim=1, pdim=0, name=:e)
 
-    # consistent device parameters within each component
+    # consistent component parameters within each component
     nwok = Network(g, [vmok, vmok], e)
     @test chk_global_parameters(nwok) == true
 
-    # inconsistent device parameters within the second component
+    # inconsistent component parameters within the second component
     nwbad = Network(g, [vmok, vmbad], e)
     @test chk_global_parameters(nwbad; verbose=false) == false
 
-    # device inconsistency is also caught automatically on ODEProblem construction
+    # component inconsistency is also caught automatically on ODEProblem construction
     s0 = NWState(nwbad)
     s0.v[:, :θ] .= 0.0
     @test_logs (:warn,) ODEProblem(nwbad, s0, (0.0, 1.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ BUILDKITE && @test CUDA.functional() # fail early in buildkite if cuda is not av
         @testfile "sparsity_test.jl"
 
         @testfile "MTK_test.jl"
+        @testfile "global_paramcheck.jl"
 
         # check on the precompile files
         @testfile "../src/precompile_workload.jl"


### PR DESCRIPTION
This PR adds a new feature, a settable `scope` for a parameter.
This is just for tracking, and throwing warnings. The idea: mark
```
@paramters begin
    Vbase, [scope=:component]
end
```
so it can be checkt that every parameter within a component (VertexModel or EdgeModel) named `somthing+Vbase` has the same number.

Similarily, you can mark stuff as global
```
@parameters begin
    Sbase, [scope=:global]
end
```
to auto check that all parameters with the magic name `Sbase` actually contain the same number.

Open questions/tasks:
- [ ] rename `:device` -> `:component` (less confusion in PowerDynamics)
- [ ] what should happen if variables have the same name, but not the same scope?  Just clarify.

This is part of the solution towards https://github.com/JuliaEnergy/PowerDynamics.jl/issues/265